### PR TITLE
Added UTC support

### DIFF
--- a/lib/makeFormatter.js
+++ b/lib/makeFormatter.js
@@ -1,5 +1,5 @@
 
-function makeFormatter(str, locale){
+function makeFormatter(str, locale, utc){
 
   var bits = [];
 
@@ -391,83 +391,87 @@ function makeFormatter(str, locale){
   var fnBody = '';
 
   if(gets.date){
-    fnBody += 'var _date = d.getDate();\n';
+    fnBody += 'var _date = d.get' + (utc ? 'UTC' : '') + 'Date();\n';
   }
 
   if(gets.month){
-    fnBody += 'var _month = d.getMonth();\n';
+    fnBody += 'var _month = d.get' + (utc ? 'UTC' : '') + 'Month();\n';
   }
 
   if(gets.dayOfYear){
     fnBody +=
           'var _startOfYear = new Date(d.valueOf());\n' +
-          '_startOfYear.setMonth(0);\n' +
-          '_startOfYear.setDate(1);\n' +
+          '_startOfYear.set' + (utc ? 'UTC' : '') + 'Month(0);\n' +
+          '_startOfYear.set' + (utc ? 'UTC' : '') + 'Date(1);\n' +
           'var _doy = Math.round((d - _startOfYear) / 864e5) + 1;\n';
   }
 
   if(gets.day){
-    fnBody += 'var _day = d.getDay();\n';
+    fnBody += 'var _day = d.get' + (utc ? 'UTC' : '') + 'Day();\n';
   }
 
   if(gets.year){
-    fnBody += 'var _year = d.getFullYear();\n';
+    fnBody += 'var _year = d.get' + (utc ? 'UTC' : '') + 'FullYear();\n';
   }
 
   if(gets.hour){
-    fnBody += 'var _hour = d.getHours();\n';
+    fnBody += 'var _hour = d.get' + (utc ? 'UTC' : '') + 'Hours();\n';
   }
 
   if(gets.minutes){
-    fnBody += 'var _mins = d.getMinutes();\n';
+    fnBody += 'var _mins = d.get' + (utc ? 'UTC' : '') + 'Minutes();\n';
   }
 
   if(gets.seconds){
-    fnBody += 'var _secs = d.getSeconds();\n';
+    fnBody += 'var _secs = d.get' + (utc ? 'UTC' : '') + 'Seconds();\n';
   }
 
   if(gets.millis){
-    fnBody += 'var _ms = d.getMilliseconds();\n';
+    fnBody += 'var _ms = d.get' + (utc ? 'UTC' : '') + 'Milliseconds();\n';
   }
 
   if(gets.offset){
-    fnBody +=
-          'var _offs = -d.getTimezoneOffset();\n' +
-          'var _absOffs = _offs < 0 ? -_offs : _offs;\n' +
-          'var _offH = Math.floor(_absOffs / 60);\n' +
-          'var _offM = _absOffs % 60;\n';
+    if (utc) {
+      fnBody += 'var _offs = 0, _absOffs = 0, _offH = 0, _offM = 0;'
+    } else {
+      fnBody +=
+            'var _offs = -d.getTimezoneOffset();\n' +
+            'var _absOffs = _offs < 0 ? -_offs : _offs;\n' +
+            'var _offH = Math.floor(_absOffs / 60);\n' +
+            'var _offM = _absOffs % 60;\n';
+    }
   }
 
   if(gets.week){
     fnBody +=  // mostly taken from moment, probably not as efficient as it could be
           'var _wend = ' + (localeWeek.doy - localeWeek.dow) + ';\n' +
-          'var _ddw = ' + (+localeWeek.doy) + ' - d.getDay();\n' +
+          'var _ddw = ' + (+localeWeek.doy) + ' - d.get' + (utc ? 'UTC' : '') + 'Day();\n' +
           'if(_ddw > _wend) _ddw -= 7;\n' +
           'if(_ddw < _wend - 7) _ddw += 7;\n' +
           'var _d2 = new Date(d.valueOf());\n' +
-          '_d2.setDate(d.getDate() + _ddw);\n' +
+          '_d2.set' + (utc ? 'UTC' : '') + 'Date(d.get' + (utc ? 'UTC' : '') + 'Date() + _ddw);\n' +
           'var _soy2 = new Date(_d2.valueOf());\n' +
-          '_soy2.setMonth(0);\n' +
-          '_soy2.setDate(1);\n' +
+          '_soy2.set' + (utc ? 'UTC' : '') + 'Month(0);\n' +
+          '_soy2.set' + (utc ? 'UTC' : '') + 'Date(1);\n' +
           'var _doy2 = Math.round((_d2 - _soy2) / 864e5) + 1;\n' +
           'var _week = Math.ceil(_doy2 / 7);\n' +
-          'var _weekYear = _d2.getFullYear();\n';
+          'var _weekYear = _d2.get' + (utc ? 'UTC' : '') + 'FullYear();\n';
   }
 
   if(gets.isoweek){
     fnBody +=  // mostly taken from moment, probably not as efficient as it could be
           'var _i_wend = 3;\n' +
-          'var _i_ddw = 4 - d.getDay();\n' +
+          'var _i_ddw = 4 - d.get' + (utc ? 'UTC' : '') + 'Day();\n' +
           'if(_i_ddw > _i_wend) _i_ddw -= 7;\n' +
           'if(_i_ddw < _i_wend - 7) _i_ddw += 7;\n' +
           'var _i_d2 = new Date(d.valueOf());\n' +
-          '_i_d2.setDate(d.getDate() + _i_ddw);\n' +
+          '_i_d2.set' + (utc ? 'UTC' : '') + 'Date(d.get' + (utc ? 'UTC' : '') + 'Date() + _i_ddw);\n' +
           'var _i_soy2 = new Date(_i_d2.valueOf());\n' +
-          '_i_soy2.setMonth(0);\n' +
-          '_i_soy2.setDate(1);\n' +
+          '_i_soy2.set' + (utc ? 'UTC' : '') + 'Month(0);\n' +
+          '_i_soy2.set' + (utc ? 'UTC' : '') + 'Date(1);\n' +
           'var _i_doy2 = Math.round((_i_d2 - _i_soy2) / 864e5) + 1;\n' +
           'var _i_week = Math.ceil(_i_doy2 / 7);\n' +
-          'var _i_weekYear = _i_d2.getFullYear();\n';
+          'var _i_weekYear = _i_d2.get' + (utc ? 'UTC' : '') + 'FullYear();\n';
   }
 
   fnBody += 'return (\n' + bits.join(' +\n') + '\n);';

--- a/lib/speed-date.js
+++ b/lib/speed-date.js
@@ -1,38 +1,43 @@
 var makeFormatter = require('./makeFormatter');
 
-function speedDate(fmt, date){
+function makeSpeedDate(utc) {
+  function speedDate(fmt, date){
 
-  if(!fmt) fmt = 'YYYY-MM-DDTHH:mm:ssZ';
+    if(!fmt) fmt = 'YYYY-MM-DDTHH:mm:ssZ';
 
-  var formatter = makeFormatter(fmt);
+    var formatter = makeFormatter(fmt, null, utc);
 
-  if(typeof date === 'undefined'){
-    return formatter;
-  }else{
-    return formatter(date);
+    if(typeof date === 'undefined'){
+      return formatter;
+    }else{
+      return formatter(date);
+    }
   }
+
+
+
+  var formatterCache = {};
+
+  speedDate.cached = function(fmt, date){
+
+    if(!fmt) fmt = 'YYYY-MM-DDTHH:mm:ssZ';
+
+    var formatter = formatterCache[fmt];
+
+    if(formatter === undefined){
+      formatter = formatterCache[fmt] = makeFormatter(fmt, null, utc);
+    }
+
+    if(typeof date === 'undefined'){
+      return formatter;
+    }else{
+      return formatter(date);
+    }
+  };
+
+  return speedDate;
 }
 
 
-
-var formatterCache = {};
-
-speedDate.cached = function(fmt, date){
-
-  if(!fmt) fmt = 'YYYY-MM-DDTHH:mm:ssZ';
-
-  var formatter = formatterCache[fmt];
-
-  if(formatter === undefined){
-    formatter = formatterCache[fmt] = makeFormatter(fmt);
-  }
-
-  if(typeof date === 'undefined'){
-    return formatter;
-  }else{
-    return formatter(date);
-  }
-};
-
-
-module.exports = speedDate;
+module.exports = makeSpeedDate(false);
+module.exports.UTC = makeSpeedDate(true);

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,14 @@ function check(d, fmt){
   };
 }
 
+function checkUTC(d, fmt){
+  d = new Date(+d);
+
+  return function(){
+    assert.equal(speedDate.UTC.cached(fmt, d), moment.utc(d).format(fmt));
+  };
+}
+
 var tokens = [
   '',
   'M',
@@ -86,6 +94,14 @@ tokens.forEach(function(token){
     var d = new Date(0);
     while(d.getFullYear() < 2100){
       it('Agrees with moment for ' + token + ' on ' + d.toISOString(), check(d, token));
+      d = new Date(+d+1328427867);
+    }
+  });
+
+  describe(token + ' UTC', function(){
+    var d = new Date(0);
+    while(d.getFullYear() < 2100){
+      it('Agrees with moment for ' + token + ' on ' + d.toISOString(), checkUTC(d, token));
       d = new Date(+d+1328427867);
     }
   });


### PR DESCRIPTION
Allows the outputting of dates with the `getUTCFooBar` methods, rather than the current `getFooBar`.

Use by running `speedDate.UTC` rather than `speedDate`. All methods are exactly the same.

``` js
var speedDate = require('speed-date');

var formatter = speedDate.UTC('YYYY-MM-DD HH:mm');
var date = new Date('2015-01-05T23:32:20-08:00');

var output = formatter(date);
console.log(output);
```

The above will always output `2015-01-06 07:32`, regardless of the local timezone.

Timezone offsets are always outputted as having no offset.

Testing added to compare with Moment's equivalent `moment.utc` function.
