### PR TITLE
More tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 node_js:
-- '0.12'
-- '0.10'
-- iojs
+  - stable
+  - '6'
+  - '5'
+  - '4'
+  - '0.12'
+  - '0.10'
+
 notifications:
   slack:
     secure: c6YIhBW+/uLDI6gs5otcemnd+YTtZmr1x4gP8oRYgR50riBb1i3Ah3NBbJoda+N1o3N/AD7sxBJz8K0Jb3t7fKSWyN4TCNE2FYucaq/6wLWb0yQqwT4rdqiPEps+8i/Vh5+W13ionL9YpZpKOo32HScS7mQZPoVEYkDusqllYd8IurNZ0PwhK76mH9B597wheWKgp88xAezzbUAI2x08/H2DpKTgHGpn9kpNSBFlbruT1e43Co4K+U4SusSSJztgwE6GpyAra/NZtpf0f+rvtkYIlAtiG7nDnHAMbYdBWItHz/xjcsIiwsXKhe2umjfmTcczavmpaUlYFzB03JVP6KE18ICOZqR32fuSnI6tJmGUex5zCyfcvLKg1eJGj3kihPhbDfLKcZO1qekPQ/AeWCO5JqSmYqyLv6+DrlUV1xp2TUcuKGXTIfiNSAR1rWPOOmpgNAi/ovtcM/gjDBM8FAFjKlICOVwT6VWHRWi/7xM3G0G6JPo700SS0RHiMVTUSfcPRqmvQ5aqQZGO1SkekA6ojcwVh49BsRsZoXPVsiCBHs5/6hd8W4zsaKJYDhfc4yVtR5cEYHFQ7yCDPVggtUcYVuVlRBT6G8vzkiCOKpZHtXX4y0eALv7f3XVAnYWnOqAr6FbCAR9nhg/TDFopZYe4HHSlz/kFFpLbuW0eFYo=

--- a/lib/makeFormatter.js
+++ b/lib/makeFormatter.js
@@ -41,6 +41,13 @@ function makeFormatter(str, locale, utc){
 
     case 'Q':
       gets.month = true;
+
+      if (/^Qo/.test(str)) {
+        add('Math.ceil((_month + 1) / 3)');
+        add('["st","nd","rd","th"][Math.floor(_month / 3)]');
+        nxt(2); continue;
+      }
+
       add('Math.ceil((_month + 1) / 3)');
       nxt(1); continue;
 
@@ -175,7 +182,8 @@ function makeFormatter(str, locale, utc){
         nxt(2); continue;
       }
 
-      break;
+      add('_year < 9999 ? _year : "+" + _year');
+      nxt(1); continue;
 
     case 'g':
       gets.week = true;
@@ -239,6 +247,17 @@ function makeFormatter(str, locale, utc){
       add('((_hour+11) % 12) + 1');
       nxt(1); continue;
 
+    case 'k':
+      gets.hour = true;
+      if(/^kk/.test(str)){
+        add('_hour > 0 && _hour < 10 ? "0" : ""');
+        add('_hour === 0 ? "24" : _hour');
+        nxt(2); continue;
+      }
+
+      add('_hour === 0 ? "24" : _hour');
+      nxt(1); continue;
+
     case 'm':
       gets.minutes = true;
       if(/^mm/.test(str)){
@@ -267,7 +286,11 @@ function makeFormatter(str, locale, utc){
         add('_ms < 100 ? "0" : ""');
         add('_ms < 10 ? "0" : ""');
         add('_ms');
-        nxt(3); continue;
+
+        var len = /^S{3,9}/.exec(str)[0].length;
+        if (len > 3) add('"' + Array(len - 2).join(0) + '"');
+
+        nxt(len); continue;
       }
 
       if(/^SS/.test(str)){

--- a/lib/speed-date.js
+++ b/lib/speed-date.js
@@ -1,9 +1,13 @@
 var makeFormatter = require('./makeFormatter');
 
+function defaultFormat(utc) {
+  return utc ? 'YYYY-MM-DDTHH:mm:ss[Z]' : 'YYYY-MM-DDTHH:mm:ssZ';
+}
+
 function makeSpeedDate(utc) {
   function speedDate(fmt, date){
 
-    if(!fmt) fmt = 'YYYY-MM-DDTHH:mm:ssZ';
+    if(!fmt) fmt = defaultFormat(utc);
 
     var formatter = makeFormatter(fmt, null, utc);
 
@@ -20,7 +24,7 @@ function makeSpeedDate(utc) {
 
   speedDate.cached = function(fmt, date){
 
-    if(!fmt) fmt = 'YYYY-MM-DDTHH:mm:ssZ';
+    if(!fmt) fmt = defaultFormat(utc);
 
     var formatter = formatterCache[fmt];
 

--- a/test/test.js
+++ b/test/test.js
@@ -104,20 +104,31 @@ var tokens = [
 
 // tokens = [ undefined ];
 
+
+var dates = [];
+
+var d = new Date(0);
+while(d.getFullYear() < 2050) {
+  dates.push(d);
+  d = new Date(+d+8328427867);
+}
+
+dates.push(
+  new Date(0, 0, 1, 0, 0, 0),
+  new Date(12345, 0, 1, 0, 0)
+);
+
+
 tokens.forEach(function(token){
   describe(token, function(){
-    var d = new Date(0);
-    while(d.getFullYear() < 2050){
+    dates.forEach(function(d) {
       it(token + ' on ' + d.toISOString(), check(d, token));
-      d = new Date(+d+8328427867);
-    }
+    });
   });
 
   describe(token + ' UTC', function(){
-    var d = new Date(0);
-    while(d.getFullYear() < 2050){
+    dates.forEach(function(d) {
       it(token + ' on ' + d.toISOString(), checkUTC(d, token));
-      d = new Date(+d+8328427867);
-    }
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,7 @@ var tokens = [
   'MMM',
   'MMMM',
   'Q',
+  'Qo',
   'D',
   'Do',
   'DD',
@@ -48,6 +49,7 @@ var tokens = [
   'WW',
   'YY',
   'YYYY',
+  'Y',
   'gg',
   'gggg',
   'GG',
@@ -58,6 +60,8 @@ var tokens = [
   'HH',
   'h',
   'hh',
+  'k',
+  'kk',
   'm',
   'mm',
   's',
@@ -65,6 +69,12 @@ var tokens = [
   'S',
   'SS',
   'SSS',
+  'SSSS',
+  'SSSSS',
+  'SSSSSS',
+  'SSSSSSS',
+  'SSSSSSSS',
+  'SSSSSSSSS',
   'Z',
   'ZZ',
   'X',
@@ -86,10 +96,13 @@ var tokens = [
   '[hi',
   '[today] dddd',
   'YYYYM', // make sure numeric tokens get concatenated rather than added
-  'HHYYYYM'
+  'HHYYYYM',
+  'SSSSSSSSSS',
+  'SSSSSSSSSSSS',
+  'SSSSSSSSSSSSSSSS' // some extra-long ones to make sure we get the max correct
 ];
 
-// tokens = ['e'];
+// tokens = [ undefined ];
 
 tokens.forEach(function(token){
   describe(token, function(){


### PR DESCRIPTION
Closes #7 

It should be noted this changes the behaviour for UTC without a formatting argument (the offset is rendered as `Z` rather than `+00:00`.

Since this has been a `0.x` for far too long this will be a `1.0.0` release, wooo! :tada: 

Tests still need to be improved to check the behaviour of `Y` for Really Big Years (they only make a difference past `9999`)
